### PR TITLE
Fix: Use cached BrightnessService in BarcodeScreen dispose

### DIFF
--- a/lib/features/barcodes/presentation/barcode_screen.dart
+++ b/lib/features/barcodes/presentation/barcode_screen.dart
@@ -25,6 +25,7 @@ class BarcodeScreen extends ConsumerStatefulWidget {
 class _BarcodeScreenState extends ConsumerState<BarcodeScreen> {
   double? _originalBrightness;
   bool _brightnessWasAdjustedByThisScreen = false;
+  BrightnessService? _brightnessService;
 
   @override
   void initState() {
@@ -38,6 +39,7 @@ class _BarcodeScreenState extends ConsumerState<BarcodeScreen> {
 
       if (autoBrightEnabled) {
         final brightnessService = ref.read(brightnessServiceProvider);
+        _brightnessService = brightnessService;
         // It's important to handle potential errors when getting current brightness
         // For example, if the platform call fails.
         try {
@@ -70,7 +72,7 @@ class _BarcodeScreenState extends ConsumerState<BarcodeScreen> {
     if (_brightnessWasAdjustedByThisScreen && _originalBrightness != null) {
       // Use a try-catch here as well, in case restoring brightness fails
       try {
-        ref.read(brightnessServiceProvider).resetBrightness();
+        _brightnessService?.resetBrightness();
       } catch (e) {
         print('Error restoring brightness in BarcodeScreen dispose: $e');
       }
@@ -117,6 +119,7 @@ class _BarcodeScreenState extends ConsumerState<BarcodeScreen> {
                         try {
                           final maxLevel = await ref.read(maxScreenBrightnessLevelProvider.future);
                           final brightnessService = ref.read(brightnessServiceProvider);
+                          _brightnessService = brightnessService;
 
                           if (_originalBrightness == null) {
                             // Try to get current brightness only if not already fetched by initState or previous double tap


### PR DESCRIPTION
Resolved "Bad state: Cannot use "ref" after the widget was disposed" error in _BarcodeScreenState's dispose method.

The BrightnessService instance is now obtained earlier in the widget's lifecycle (in _setupBrightness and onDoubleTap) and stored in a class-level variable `_brightnessService`.

The dispose method now uses this cached `_brightnessService` instance to call `resetBrightness()`, avoiding the use of `ref.read()` after the widget has been disposed.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
