### PR TITLE
feat: Add setting for barcode display mode

### DIFF
--- a/lib/app_startup.g.dart
+++ b/lib/app_startup.g.dart
@@ -13,7 +13,9 @@ String _$appStartupHash() => r'9e8399f54de21614fb8d00fb7f65762ba4a0072f';
 final appStartupProvider = FutureProvider<void>.internal(
   appStartup,
   name: r'appStartupProvider',
-  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product') ? null : _$appStartupHash,
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$appStartupHash,
   dependencies: null,
   allTransitiveDependencies: null,
 );

--- a/lib/features/barcodes/data/barcode_repository.g.dart
+++ b/lib/features/barcodes/data/barcode_repository.g.dart
@@ -13,7 +13,9 @@ String _$barcodeRepositoryHash() => r'9c73fcdd40549ecf34f86f66ab39c3b5ab37bc47';
 final barcodeRepositoryProvider = Provider<BarcodeRepository>.internal(
   barcodeRepository,
   name: r'barcodeRepositoryProvider',
-  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product') ? null : _$barcodeRepositoryHash,
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$barcodeRepositoryHash,
   dependencies: null,
   allTransitiveDependencies: null,
 );
@@ -25,13 +27,16 @@ String _$barcodesStreamHash() => r'c0bd3932abe84cfebe627cce1139cbdc35e5dd7d';
 
 /// See also [barcodesStream].
 @ProviderFor(barcodesStream)
-final barcodesStreamProvider = AutoDisposeStreamProvider<List<BarcodeEntry>>.internal(
-  barcodesStream,
-  name: r'barcodesStreamProvider',
-  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product') ? null : _$barcodesStreamHash,
-  dependencies: null,
-  allTransitiveDependencies: null,
-);
+final barcodesStreamProvider =
+    AutoDisposeStreamProvider<List<BarcodeEntry>>.internal(
+      barcodesStream,
+      name: r'barcodesStreamProvider',
+      debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+          ? null
+          : _$barcodesStreamHash,
+      dependencies: null,
+      allTransitiveDependencies: null,
+    );
 
 @Deprecated('Will be removed in 3.0. Use Ref instead')
 // ignore: unused_element
@@ -88,7 +93,8 @@ class BarcodeStreamFamily extends Family<AsyncValue<BarcodeEntry?>> {
   static const Iterable<ProviderOrFamily>? _allTransitiveDependencies = null;
 
   @override
-  Iterable<ProviderOrFamily>? get allTransitiveDependencies => _allTransitiveDependencies;
+  Iterable<ProviderOrFamily>? get allTransitiveDependencies =>
+      _allTransitiveDependencies;
 
   @override
   String? get name => r'barcodeStreamProvider';
@@ -102,9 +108,12 @@ class BarcodeStreamProvider extends AutoDisposeStreamProvider<BarcodeEntry?> {
         (ref) => barcodeStream(ref as BarcodeStreamRef, entryId),
         from: barcodeStreamProvider,
         name: r'barcodeStreamProvider',
-        debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product') ? null : _$barcodeStreamHash,
+        debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+            ? null
+            : _$barcodeStreamHash,
         dependencies: BarcodeStreamFamily._dependencies,
-        allTransitiveDependencies: BarcodeStreamFamily._allTransitiveDependencies,
+        allTransitiveDependencies:
+            BarcodeStreamFamily._allTransitiveDependencies,
         entryId: entryId,
       );
 
@@ -164,7 +173,9 @@ mixin BarcodeStreamRef on AutoDisposeStreamProviderRef<BarcodeEntry?> {
   int get entryId;
 }
 
-class _BarcodeStreamProviderElement extends AutoDisposeStreamProviderElement<BarcodeEntry?> with BarcodeStreamRef {
+class _BarcodeStreamProviderElement
+    extends AutoDisposeStreamProviderElement<BarcodeEntry?>
+    with BarcodeStreamRef {
   _BarcodeStreamProviderElement(super.provider);
 
   @override

--- a/lib/features/barcodes/domain/barcode_entry.g.dart
+++ b/lib/features/barcodes/domain/barcode_entry.g.dart
@@ -6,21 +6,23 @@ part of 'barcode_entry.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_BarcodeEntry _$BarcodeEntryFromJson(Map<String, dynamic> json) => _BarcodeEntry(
-  name: json['name'] as String,
-  data: json['data'] as String,
-  type: $enumDecode(_$BarcodeTypeEnumMap, json['type']),
-  comment: json['comment'] as String?,
-  id: (json['id'] as num?)?.toInt() ?? -1,
-);
+_BarcodeEntry _$BarcodeEntryFromJson(Map<String, dynamic> json) =>
+    _BarcodeEntry(
+      name: json['name'] as String,
+      data: json['data'] as String,
+      type: $enumDecode(_$BarcodeTypeEnumMap, json['type']),
+      comment: json['comment'] as String?,
+      id: (json['id'] as num?)?.toInt() ?? -1,
+    );
 
-Map<String, dynamic> _$BarcodeEntryToJson(_BarcodeEntry instance) => <String, dynamic>{
-  'name': instance.name,
-  'data': instance.data,
-  'type': _$BarcodeTypeEnumMap[instance.type]!,
-  'comment': instance.comment,
-  'id': instance.id,
-};
+Map<String, dynamic> _$BarcodeEntryToJson(_BarcodeEntry instance) =>
+    <String, dynamic>{
+      'name': instance.name,
+      'data': instance.data,
+      'type': _$BarcodeTypeEnumMap[instance.type]!,
+      'comment': instance.comment,
+      'id': instance.id,
+    };
 
 const _$BarcodeTypeEnumMap = {
   BarcodeType.CodeITF16: 'CodeITF16',

--- a/lib/features/barcodes/presentation/barcodes_list_controller.g.dart
+++ b/lib/features/barcodes/presentation/barcodes_list_controller.g.dart
@@ -6,17 +6,21 @@ part of 'barcodes_list_controller.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$barcodesListControllerHash() => r'6938aa46315e68b1a9e7a2efd85161ea733eeb3d';
+String _$barcodesListControllerHash() =>
+    r'6938aa46315e68b1a9e7a2efd85161ea733eeb3d';
 
 /// See also [BarcodesListController].
 @ProviderFor(BarcodesListController)
-final barcodesListControllerProvider = AutoDisposeAsyncNotifierProvider<BarcodesListController, void>.internal(
-  BarcodesListController.new,
-  name: r'barcodesListControllerProvider',
-  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product') ? null : _$barcodesListControllerHash,
-  dependencies: null,
-  allTransitiveDependencies: null,
-);
+final barcodesListControllerProvider =
+    AutoDisposeAsyncNotifierProvider<BarcodesListController, void>.internal(
+      BarcodesListController.new,
+      name: r'barcodesListControllerProvider',
+      debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+          ? null
+          : _$barcodesListControllerHash,
+      dependencies: null,
+      allTransitiveDependencies: null,
+    );
 
 typedef _$BarcodesListController = AutoDisposeAsyncNotifier<void>;
 // ignore_for_file: type=lint

--- a/lib/features/barcodes/presentation/barcodes_page.dart
+++ b/lib/features/barcodes/presentation/barcodes_page.dart
@@ -1,4 +1,6 @@
+import 'package:barcodes/common_widgets/async_value_widget.dart';
 import 'package:barcodes/features/barcodes/presentation/barcodes_list.dart';
+import 'package:barcodes/features/settings/data/settings_repository.dart';
 import 'package:barcodes/l10n/l10n.dart';
 import 'package:barcodes/routing/app_routes.dart';
 import 'package:flutter/material.dart';
@@ -10,11 +12,25 @@ class BarcodesPage extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    final barcodeDisplayModeAsync = ref.watch(barcodeDisplayModeProvider);
     return Scaffold(
       appBar: AppBar(
         title: Text(context.l10n.appBarTitleBarcodes),
       ),
-      body: const BarcodesList(),
+      body: AsyncValueWidget<BarcodeDisplayMode>(
+        value: barcodeDisplayModeAsync,
+        data: (displayMode) {
+          if (displayMode == BarcodeDisplayMode.list) {
+            return const BarcodesList();
+          } else if (displayMode == BarcodeDisplayMode.carousel) {
+            return const Center(
+              child: Text('Carousel view coming soon!'),
+            );
+          }
+          // Default fallback, though ideally should not be reached if enum is handled exhaustively.
+          return const BarcodesList();
+        },
+      ),
       floatingActionButton: FloatingActionButton(
         onPressed: () => context.goNamed(AddEntryRoute.name),
         child: const Icon(Icons.add),

--- a/lib/features/categories/data/category_repository.g.dart
+++ b/lib/features/categories/data/category_repository.g.dart
@@ -6,14 +6,17 @@ part of 'category_repository.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$categoryRepositoryHash() => r'310b67c2104ad85d8c113cd5e83add7eacbdbae9';
+String _$categoryRepositoryHash() =>
+    r'310b67c2104ad85d8c113cd5e83add7eacbdbae9';
 
 /// See also [categoryRepository].
 @ProviderFor(categoryRepository)
 final categoryRepositoryProvider = Provider<CategoryRepository>.internal(
   categoryRepository,
   name: r'categoryRepositoryProvider',
-  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product') ? null : _$categoryRepositoryHash,
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$categoryRepositoryHash,
   dependencies: null,
   allTransitiveDependencies: null,
 );

--- a/lib/features/categories/domain/category.freezed.dart
+++ b/lib/features/categories/domain/category.freezed.dart
@@ -16,10 +16,10 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$Category {
 
-// For Sembast, the ID is the record key.
+ String get name;// For Sembast, the ID is the record key.
 // It's often not stored as part of the JSON value itself if auto-generated.
 // Making it potentially null for new objects not yet saved.
- int? get id; String get name;
+ int? get id;
 /// Create a copy of Category
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -32,16 +32,16 @@ $CategoryCopyWith<Category> get copyWith => _$CategoryCopyWithImpl<Category>(thi
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is Category&&(identical(other.id, id) || other.id == id)&&(identical(other.name, name) || other.name == name));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is Category&&(identical(other.name, name) || other.name == name)&&(identical(other.id, id) || other.id == id));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,id,name);
+int get hashCode => Object.hash(runtimeType,name,id);
 
 @override
 String toString() {
-  return 'Category(id: $id, name: $name)';
+  return 'Category(name: $name, id: $id)';
 }
 
 
@@ -52,7 +52,7 @@ abstract mixin class $CategoryCopyWith<$Res>  {
   factory $CategoryCopyWith(Category value, $Res Function(Category) _then) = _$CategoryCopyWithImpl;
 @useResult
 $Res call({
- int? id, String name
+ String name, int? id
 });
 
 
@@ -69,11 +69,11 @@ class _$CategoryCopyWithImpl<$Res>
 
 /// Create a copy of Category
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? id = freezed,Object? name = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? name = null,Object? id = freezed,}) {
   return _then(_self.copyWith(
-id: freezed == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
-as int?,name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
-as String,
+name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
+as String,id: freezed == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as int?,
   ));
 }
 
@@ -84,14 +84,14 @@ as String,
 @JsonSerializable()
 
 class _Category implements Category {
-  const _Category({this.id, required this.name});
+  const _Category({required this.name, this.id});
   factory _Category.fromJson(Map<String, dynamic> json) => _$CategoryFromJson(json);
 
+@override final  String name;
 // For Sembast, the ID is the record key.
 // It's often not stored as part of the JSON value itself if auto-generated.
 // Making it potentially null for new objects not yet saved.
 @override final  int? id;
-@override final  String name;
 
 /// Create a copy of Category
 /// with the given fields replaced by the non-null parameter values.
@@ -106,16 +106,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _Category&&(identical(other.id, id) || other.id == id)&&(identical(other.name, name) || other.name == name));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _Category&&(identical(other.name, name) || other.name == name)&&(identical(other.id, id) || other.id == id));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,id,name);
+int get hashCode => Object.hash(runtimeType,name,id);
 
 @override
 String toString() {
-  return 'Category(id: $id, name: $name)';
+  return 'Category(name: $name, id: $id)';
 }
 
 
@@ -126,7 +126,7 @@ abstract mixin class _$CategoryCopyWith<$Res> implements $CategoryCopyWith<$Res>
   factory _$CategoryCopyWith(_Category value, $Res Function(_Category) _then) = __$CategoryCopyWithImpl;
 @override @useResult
 $Res call({
- int? id, String name
+ String name, int? id
 });
 
 
@@ -143,11 +143,11 @@ class __$CategoryCopyWithImpl<$Res>
 
 /// Create a copy of Category
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? id = freezed,Object? name = null,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? name = null,Object? id = freezed,}) {
   return _then(_Category(
-id: freezed == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
-as int?,name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
-as String,
+name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
+as String,id: freezed == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as int?,
   ));
 }
 

--- a/lib/features/categories/domain/category.g.dart
+++ b/lib/features/categories/domain/category.g.dart
@@ -7,9 +7,9 @@ part of 'category.dart';
 // **************************************************************************
 
 _Category _$CategoryFromJson(Map<String, dynamic> json) =>
-    _Category(id: (json['id'] as num?)?.toInt(), name: json['name'] as String);
+    _Category(name: json['name'] as String, id: (json['id'] as num?)?.toInt());
 
 Map<String, dynamic> _$CategoryToJson(_Category instance) => <String, dynamic>{
-  'id': instance.id,
   'name': instance.name,
+  'id': instance.id,
 };

--- a/lib/features/settings/data/settings_repository.dart
+++ b/lib/features/settings/data/settings_repository.dart
@@ -7,6 +7,12 @@ part 'settings_repository.g.dart';
 
 const String kAutomaticScreenBrightness = 'automaticScreenBrightness';
 const String kMaxScreenBrightnessLevel = 'maxScreenBrightnessLevel';
+const String kBarcodeDisplayMode = 'barcodeDisplayMode';
+
+enum BarcodeDisplayMode {
+  list,
+  carousel,
+}
 
 @Riverpod(keepAlive: true)
 SettingsRepository settingsRepository(Ref ref) {
@@ -21,6 +27,11 @@ Future<bool> automaticScreenBrightness(Ref ref) {
 @riverpod
 Future<double> maxScreenBrightnessLevel(Ref ref) {
   return ref.watch(settingsRepositoryProvider).getMaxScreenBrightnessLevel();
+}
+
+@riverpod
+Future<BarcodeDisplayMode> barcodeDisplayMode(BarcodeDisplayModeRef ref) {
+  return ref.watch(settingsRepositoryProvider).getBarcodeDisplayMode();
 }
 
 class SettingsRepository {
@@ -48,5 +59,20 @@ class SettingsRepository {
 
   Future<void> setMaxScreenBrightnessLevel(double value) async {
     await storeRef.record(kMaxScreenBrightnessLevel).put(datastore.db, value);
+  }
+
+  Future<BarcodeDisplayMode> getBarcodeDisplayMode() async {
+    final value = await storeRef.record(kBarcodeDisplayMode).get(datastore.db);
+    if (value == null) {
+      return BarcodeDisplayMode.list;
+    }
+    return BarcodeDisplayMode.values.firstWhere(
+      (e) => e.toString() == 'BarcodeDisplayMode.$value',
+      orElse: () => BarcodeDisplayMode.list,
+    );
+  }
+
+  Future<void> setBarcodeDisplayMode(BarcodeDisplayMode mode) async {
+    await storeRef.record(kBarcodeDisplayMode).put(datastore.db, mode.name);
   }
 }

--- a/lib/features/settings/data/settings_repository.g.dart
+++ b/lib/features/settings/data/settings_repository.g.dart
@@ -6,14 +6,17 @@ part of 'settings_repository.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$settingsRepositoryHash() => r'49ad17730608151ac0ace54ab7b0875c4103f589';
+String _$settingsRepositoryHash() =>
+    r'49ad17730608151ac0ace54ab7b0875c4103f589';
 
 /// See also [settingsRepository].
 @ProviderFor(settingsRepository)
 final settingsRepositoryProvider = Provider<SettingsRepository>.internal(
   settingsRepository,
   name: r'settingsRepositoryProvider',
-  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product') ? null : _$settingsRepositoryHash,
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$settingsRepositoryHash,
   dependencies: null,
   allTransitiveDependencies: null,
 );
@@ -21,35 +24,63 @@ final settingsRepositoryProvider = Provider<SettingsRepository>.internal(
 @Deprecated('Will be removed in 3.0. Use Ref instead')
 // ignore: unused_element
 typedef SettingsRepositoryRef = ProviderRef<SettingsRepository>;
-String _$automaticScreenBrightnessHash() => r'a5728986e211ddddc5722e7135baaffa47ceafd8';
+String _$automaticScreenBrightnessHash() =>
+    r'56f4c6664049c468ea1130887ec8b91285742458';
 
 /// See also [automaticScreenBrightness].
 @ProviderFor(automaticScreenBrightness)
-final automaticScreenBrightnessProvider = AutoDisposeFutureProvider<bool>.internal(
-  automaticScreenBrightness,
-  name: r'automaticScreenBrightnessProvider',
-  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product') ? null : _$automaticScreenBrightnessHash,
-  dependencies: null,
-  allTransitiveDependencies: null,
-);
+final automaticScreenBrightnessProvider =
+    AutoDisposeFutureProvider<bool>.internal(
+      automaticScreenBrightness,
+      name: r'automaticScreenBrightnessProvider',
+      debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+          ? null
+          : _$automaticScreenBrightnessHash,
+      dependencies: null,
+      allTransitiveDependencies: null,
+    );
 
 @Deprecated('Will be removed in 3.0. Use Ref instead')
 // ignore: unused_element
 typedef AutomaticScreenBrightnessRef = AutoDisposeFutureProviderRef<bool>;
-String _$maxScreenBrightnessLevelHash() => r'7fee483f5c130003a67be96a8018e6455476edf2';
+String _$maxScreenBrightnessLevelHash() =>
+    r'130c3b84cead305df15e202c0b236e1aa5f6d9df';
 
 /// See also [maxScreenBrightnessLevel].
 @ProviderFor(maxScreenBrightnessLevel)
-final maxScreenBrightnessLevelProvider = AutoDisposeFutureProvider<double>.internal(
-  maxScreenBrightnessLevel,
-  name: r'maxScreenBrightnessLevelProvider',
-  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product') ? null : _$maxScreenBrightnessLevelHash,
-  dependencies: null,
-  allTransitiveDependencies: null,
-);
+final maxScreenBrightnessLevelProvider =
+    AutoDisposeFutureProvider<double>.internal(
+      maxScreenBrightnessLevel,
+      name: r'maxScreenBrightnessLevelProvider',
+      debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+          ? null
+          : _$maxScreenBrightnessLevelHash,
+      dependencies: null,
+      allTransitiveDependencies: null,
+    );
 
 @Deprecated('Will be removed in 3.0. Use Ref instead')
 // ignore: unused_element
 typedef MaxScreenBrightnessLevelRef = AutoDisposeFutureProviderRef<double>;
+String _$barcodeDisplayModeHash() =>
+    r'efeac66664c1dcf6e405202b80155173a954dd1b';
+
+/// See also [barcodeDisplayMode].
+@ProviderFor(barcodeDisplayMode)
+final barcodeDisplayModeProvider =
+    AutoDisposeFutureProvider<BarcodeDisplayMode>.internal(
+      barcodeDisplayMode,
+      name: r'barcodeDisplayModeProvider',
+      debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+          ? null
+          : _$barcodeDisplayModeHash,
+      dependencies: null,
+      allTransitiveDependencies: null,
+    );
+
+@Deprecated('Will be removed in 3.0. Use Ref instead')
+// ignore: unused_element
+typedef BarcodeDisplayModeRef =
+    AutoDisposeFutureProviderRef<BarcodeDisplayMode>;
 // ignore_for_file: type=lint
 // ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/lib/features/settings/presentation/settings_page.dart
+++ b/lib/features/settings/presentation/settings_page.dart
@@ -15,6 +15,7 @@ class SettingsPage extends ConsumerWidget {
     final packageInfo = ref.watch(packageInfoProvider);
     final automaticBrightness = ref.watch(automaticScreenBrightnessProvider);
     final maxBrightness = ref.watch(maxScreenBrightnessLevelProvider);
+    final barcodeDisplayMode = ref.watch(barcodeDisplayModeProvider); // This should already be correct if I followed the convention. Let's double check.
 
     // Determine if the slider should be enabled
     // It's enabled if automatic brightness is ON (true) and has data.
@@ -101,6 +102,32 @@ class SettingsPage extends ConsumerWidget {
               // Navigate using GoRouter's named route
               context.pushNamed(ManageCategoriesRoute.name);
             },
+          ),
+          const Divider(),
+          ListTile(
+            title: Text(context.l10n.settingsBarcodeDisplayModeTitle),
+          ),
+          AsyncValueWidget<BarcodeDisplayMode>(
+            value: barcodeDisplayMode, // This should be correct
+            data: (currentMode) => SegmentedButton<BarcodeDisplayMode>(
+              segments: <ButtonSegment<BarcodeDisplayMode>>[
+                ButtonSegment<BarcodeDisplayMode>(
+                  value: BarcodeDisplayMode.list,
+                  label: Text(context.l10n.settingsBarcodeDisplayModeList),
+                ),
+                ButtonSegment<BarcodeDisplayMode>(
+                  value: BarcodeDisplayMode.carousel,
+                  label: Text(context.l10n.settingsBarcodeDisplayModeCarousel),
+                ),
+              ],
+              selected: <BarcodeDisplayMode>{currentMode},
+              onSelectionChanged: (Set<BarcodeDisplayMode> newSelection) {
+                if (newSelection.isNotEmpty) {
+                  ref.read(settingsRepositoryProvider).setBarcodeDisplayMode(newSelection.first);
+                  ref.invalidate(barcodeDisplayModeProvider); // This should be correct
+                }
+              },
+            ),
           ),
         ],
       ),

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -189,5 +189,8 @@
         "example": "Groceries"
       }
     }
-  }
+  },
+  "settingsBarcodeDisplayModeTitle": "Barcode Display Mode",
+  "settingsBarcodeDisplayModeList": "List",
+  "settingsBarcodeDisplayModeCarousel": "Carousel"
 }

--- a/lib/l10n/arb/app_es.arb
+++ b/lib/l10n/arb/app_es.arb
@@ -49,5 +49,8 @@
                 "type": "String"
             }
         }
-    }
+    },
+  "settingsBarcodeDisplayModeTitle": "Modo de visualización de códigos de barras",
+  "settingsBarcodeDisplayModeList": "Lista",
+  "settingsBarcodeDisplayModeCarousel": "Carrusel"
 }

--- a/lib/routing/app_router.g.dart
+++ b/lib/routing/app_router.g.dart
@@ -13,7 +13,9 @@ String _$goRouterHash() => r'c3ac2550c9d4252e8aeb20c213bf5ea26d4eaed6';
 final goRouterProvider = AutoDisposeProvider<GoRouter>.internal(
   goRouter,
   name: r'goRouterProvider',
-  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product') ? null : _$goRouterHash,
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$goRouterHash,
   dependencies: null,
   allTransitiveDependencies: null,
 );

--- a/lib/routing/app_routes.g.dart
+++ b/lib/routing/app_routes.g.dart
@@ -57,11 +57,13 @@ RouteBase get $mainShellRouteData => StatefulShellRouteData.$route(
 );
 
 extension $MainShellRouteDataExtension on MainShellRouteData {
-  static MainShellRouteData _fromState(GoRouterState state) => const MainShellRouteData();
+  static MainShellRouteData _fromState(GoRouterState state) =>
+      const MainShellRouteData();
 }
 
 extension $BarcodesPageRouteExtension on BarcodesPageRoute {
-  static BarcodesPageRoute _fromState(GoRouterState state) => BarcodesPageRoute();
+  static BarcodesPageRoute _fromState(GoRouterState state) =>
+      BarcodesPageRoute();
 
   String get location => GoRouteData.$location('/');
 
@@ -69,13 +71,15 @@ extension $BarcodesPageRouteExtension on BarcodesPageRoute {
 
   Future<T?> push<T>(BuildContext context) => context.push<T>(location);
 
-  void pushReplacement(BuildContext context) => context.pushReplacement(location);
+  void pushReplacement(BuildContext context) =>
+      context.pushReplacement(location);
 
   void replace(BuildContext context) => context.replace(location);
 }
 
 extension $BarcodeRouteExtension on BarcodeRoute {
-  static BarcodeRoute _fromState(GoRouterState state) => BarcodeRoute(int.parse(state.pathParameters['eid']!)!);
+  static BarcodeRoute _fromState(GoRouterState state) =>
+      BarcodeRoute(int.parse(state.pathParameters['eid']!)!);
 
   String get location => GoRouteData.$location(
     '/barcode/show/${Uri.encodeComponent(eid.toString())}',
@@ -85,7 +89,8 @@ extension $BarcodeRouteExtension on BarcodeRoute {
 
   Future<T?> push<T>(BuildContext context) => context.push<T>(location);
 
-  void pushReplacement(BuildContext context) => context.pushReplacement(location);
+  void pushReplacement(BuildContext context) =>
+      context.pushReplacement(location);
 
   void replace(BuildContext context) => context.replace(location);
 }
@@ -99,13 +104,15 @@ extension $AddEntryRouteExtension on AddEntryRoute {
 
   Future<T?> push<T>(BuildContext context) => context.push<T>(location);
 
-  void pushReplacement(BuildContext context) => context.pushReplacement(location);
+  void pushReplacement(BuildContext context) =>
+      context.pushReplacement(location);
 
   void replace(BuildContext context) => context.replace(location);
 }
 
 extension $SettingsPageRouteExtension on SettingsPageRoute {
-  static SettingsPageRoute _fromState(GoRouterState state) => SettingsPageRoute();
+  static SettingsPageRoute _fromState(GoRouterState state) =>
+      SettingsPageRoute();
 
   String get location => GoRouteData.$location('/settings');
 
@@ -113,13 +120,15 @@ extension $SettingsPageRouteExtension on SettingsPageRoute {
 
   Future<T?> push<T>(BuildContext context) => context.push<T>(location);
 
-  void pushReplacement(BuildContext context) => context.pushReplacement(location);
+  void pushReplacement(BuildContext context) =>
+      context.pushReplacement(location);
 
   void replace(BuildContext context) => context.replace(location);
 }
 
 extension $ManageCategoriesRouteExtension on ManageCategoriesRoute {
-  static ManageCategoriesRoute _fromState(GoRouterState state) => const ManageCategoriesRoute();
+  static ManageCategoriesRoute _fromState(GoRouterState state) =>
+      const ManageCategoriesRoute();
 
   String get location => GoRouteData.$location('/settings/categories');
 
@@ -127,7 +136,8 @@ extension $ManageCategoriesRouteExtension on ManageCategoriesRoute {
 
   Future<T?> push<T>(BuildContext context) => context.push<T>(location);
 
-  void pushReplacement(BuildContext context) => context.pushReplacement(location);
+  void pushReplacement(BuildContext context) =>
+      context.pushReplacement(location);
 
   void replace(BuildContext context) => context.replace(location);
 }

--- a/lib/utils/brightness_service.g.dart
+++ b/lib/utils/brightness_service.g.dart
@@ -13,7 +13,9 @@ String _$brightnessServiceHash() => r'e3d32e70837dc353320cbd04622e7979c8f9fb53';
 final brightnessServiceProvider = Provider<BrightnessService>.internal(
   brightnessService,
   name: r'brightnessServiceProvider',
-  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product') ? null : _$brightnessServiceHash,
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$brightnessServiceHash,
   dependencies: null,
   allTransitiveDependencies: null,
 );

--- a/lib/utils/data_store.g.dart
+++ b/lib/utils/data_store.g.dart
@@ -13,7 +13,9 @@ String _$dataStoreHash() => r'fe2107a035cbdc3e46d3b7010d5a64599dfbeb4c';
 final dataStoreProvider = FutureProvider<DataStore>.internal(
   dataStore,
   name: r'dataStoreProvider',
-  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product') ? null : _$dataStoreHash,
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$dataStoreHash,
   dependencies: null,
   allTransitiveDependencies: null,
 );

--- a/lib/utils/logger.g.dart
+++ b/lib/utils/logger.g.dart
@@ -13,7 +13,9 @@ String _$loggerHash() => r'09c5b3af792366a31741a2765c0844e854c6764c';
 final loggerProvider = AutoDisposeProvider<Logger>.internal(
   logger,
   name: r'loggerProvider',
-  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product') ? null : _$loggerHash,
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$loggerHash,
   dependencies: null,
   allTransitiveDependencies: null,
 );

--- a/lib/utils/package_info.g.dart
+++ b/lib/utils/package_info.g.dart
@@ -13,7 +13,9 @@ String _$packageInfoHash() => r'854bbb0e381edfdddbd736229351d6cc918a2ad1';
 final packageInfoProvider = FutureProvider<PackageInfo>.internal(
   packageInfo,
   name: r'packageInfoProvider',
-  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product') ? null : _$packageInfoHash,
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$packageInfoHash,
   dependencies: null,
   allTransitiveDependencies: null,
 );

--- a/test/features/barcodes/presentation/barcode_screen_test.mocks.dart
+++ b/test/features/barcodes/presentation/barcode_screen_test.mocks.dart
@@ -6,8 +6,10 @@
 import 'dart:async' as _i6;
 
 import 'package:barcodes/features/barcodes/domain/barcode_entry.dart' as _i9;
-import 'package:barcodes/features/barcodes/presentation/barcodes_list_controller.dart' as _i8;
-import 'package:barcodes/features/settings/data/settings_repository.dart' as _i7;
+import 'package:barcodes/features/barcodes/presentation/barcodes_list_controller.dart'
+    as _i8;
+import 'package:barcodes/features/settings/data/settings_repository.dart'
+    as _i7;
 import 'package:barcodes/utils/brightness_service.dart' as _i5;
 import 'package:barcodes/utils/data_store.dart' as _i2;
 import 'package:flutter_riverpod/flutter_riverpod.dart' as _i4;
@@ -29,11 +31,15 @@ import 'package:sembast/sembast.dart' as _i3;
 // ignore_for_file: subtype_of_sealed_class
 
 class _FakeDataStore_0 extends _i1.SmartFake implements _i2.DataStore {
-  _FakeDataStore_0(Object parent, Invocation parentInvocation) : super(parent, parentInvocation);
+  _FakeDataStore_0(Object parent, Invocation parentInvocation)
+    : super(parent, parentInvocation);
 }
 
-class _FakeStoreRef_1<K extends Object?, V extends Object?> extends _i1.SmartFake implements _i3.StoreRef<K, V> {
-  _FakeStoreRef_1(Object parent, Invocation parentInvocation) : super(parent, parentInvocation);
+class _FakeStoreRef_1<K extends Object?, V extends Object?>
+    extends _i1.SmartFake
+    implements _i3.StoreRef<K, V> {
+  _FakeStoreRef_1(Object parent, Invocation parentInvocation)
+    : super(parent, parentInvocation);
 }
 
 class _FakeAutoDisposeAsyncNotifierProviderRef_2<T> extends _i1.SmartFake
@@ -45,7 +51,8 @@ class _FakeAutoDisposeAsyncNotifierProviderRef_2<T> extends _i1.SmartFake
 }
 
 class _FakeAsyncValue_3<T> extends _i1.SmartFake implements _i4.AsyncValue<T> {
-  _FakeAsyncValue_3(Object parent, Invocation parentInvocation) : super(parent, parentInvocation);
+  _FakeAsyncValue_3(Object parent, Invocation parentInvocation)
+    : super(parent, parentInvocation);
 }
 
 /// A class which mocks [BrightnessService].
@@ -86,7 +93,8 @@ class MockBrightnessService extends _i1.Mock implements _i5.BrightnessService {
 /// A class which mocks [SettingsRepository].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockSettingsRepository extends _i1.Mock implements _i7.SettingsRepository {
+class MockSettingsRepository extends _i1.Mock
+    implements _i7.SettingsRepository {
   MockSettingsRepository() {
     _i1.throwOnMissingStub(this);
   }
@@ -147,12 +155,32 @@ class MockSettingsRepository extends _i1.Mock implements _i7.SettingsRepository 
             returnValueForMissingStub: _i6.Future<void>.value(),
           )
           as _i6.Future<void>);
+
+  @override
+  _i6.Future<_i7.BarcodeDisplayMode> getBarcodeDisplayMode() =>
+      (super.noSuchMethod(
+            Invocation.method(#getBarcodeDisplayMode, []),
+            returnValue: _i6.Future<_i7.BarcodeDisplayMode>.value(
+              _i7.BarcodeDisplayMode.list,
+            ),
+          )
+          as _i6.Future<_i7.BarcodeDisplayMode>);
+
+  @override
+  _i6.Future<void> setBarcodeDisplayMode(_i7.BarcodeDisplayMode? mode) =>
+      (super.noSuchMethod(
+            Invocation.method(#setBarcodeDisplayMode, [mode]),
+            returnValue: _i6.Future<void>.value(),
+            returnValueForMissingStub: _i6.Future<void>.value(),
+          )
+          as _i6.Future<void>);
 }
 
 /// A class which mocks [BarcodesListController].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockBarcodesListController extends _i1.Mock implements _i8.BarcodesListController {
+class MockBarcodesListController extends _i1.Mock
+    implements _i8.BarcodesListController {
   MockBarcodesListController() {
     _i1.throwOnMissingStub(this);
   }

--- a/test/features/barcodes/presentation/barcodes_page_test.dart
+++ b/test/features/barcodes/presentation/barcodes_page_test.dart
@@ -1,0 +1,92 @@
+import 'package:barcodes/features/barcodes/presentation/barcodes_list.dart';
+import 'package:barcodes/features/barcodes/presentation/barcodes_page.dart';
+import 'package:barcodes/features/settings/data/settings_repository.dart';
+import 'package:barcodes/l10n/generated/app_localizations.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+// Helper widget to wrap BarcodesPage for testing
+class TestBarcodesPageWidget extends StatelessWidget {
+  final List<Override> overrides;
+
+  const TestBarcodesPageWidget({super.key, this.overrides = const []});
+
+  @override
+  Widget build(BuildContext context) {
+    return ProviderScope(
+      overrides: overrides,
+      child: MaterialApp(
+        // Adding localizations delegates for any text that might be in BarcodesPage (e.g., AppBar title)
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: const BarcodesPage(),
+      ),
+    );
+  }
+}
+
+void main() {
+  group('BarcodesPage conditional display', () {
+    testWidgets('displays BarcodesList when display mode is list', (WidgetTester tester) async {
+      // Arrange
+      await tester.pumpWidget(
+        TestBarcodesPageWidget(
+          overrides: [
+            barcodeDisplayModeProvider.overrideWith((ref) => Future.value(BarcodeDisplayMode.list)),
+          ],
+        ),
+      );
+
+      // Act
+      await tester.pumpAndSettle(); // Wait for futures to resolve
+
+      // Assert
+      expect(find.byType(BarcodesList), findsOneWidget);
+      expect(find.text('Carousel view coming soon!'), findsNothing);
+    });
+
+    testWidgets('displays placeholder when display mode is carousel', (WidgetTester tester) async {
+      // Arrange
+      await tester.pumpWidget(
+        TestBarcodesPageWidget(
+          overrides: [
+            barcodeDisplayModeProvider.overrideWith((ref) => Future.value(BarcodeDisplayMode.carousel)),
+          ],
+        ),
+      );
+
+      // Act
+      await tester.pumpAndSettle(); // Wait for futures to resolve
+
+      // Assert
+      expect(find.byType(BarcodesList), findsNothing);
+      expect(find.text('Carousel view coming soon!'), findsOneWidget);
+    });
+
+    testWidgets('displays loading indicator when provider is loading, then content', (WidgetTester tester) async {
+      // Arrange
+      await tester.pumpWidget(
+        TestBarcodesPageWidget(
+          overrides: [
+            barcodeDisplayModeProvider.overrideWith(
+              (ref) => Future.delayed(const Duration(milliseconds: 100), () => BarcodeDisplayMode.list),
+            ),
+          ],
+        ),
+      );
+
+      // Act & Assert for loading state
+      // pump() once to show loading state, not pumpAndSettle()
+      await tester.pump();
+      expect(find.byType(CircularProgressIndicator), findsOneWidget);
+      expect(find.byType(BarcodesList), findsNothing); // Should not be there yet
+
+      // Act & Assert for data state
+      await tester.pumpAndSettle(); // Wait for the future to complete
+      expect(find.byType(CircularProgressIndicator), findsNothing); // Should be gone
+      expect(find.byType(BarcodesList), findsOneWidget); // List should now be visible
+      expect(find.text('Carousel view coming soon!'), findsNothing);
+    });
+  });
+}

--- a/test/features/settings/data/settings_repository_test.dart
+++ b/test/features/settings/data/settings_repository_test.dart
@@ -79,5 +79,27 @@ void main() {
         expect(value, isA<double>());
       });
     });
+
+    group('barcodeDisplayMode', () {
+      test('getBarcodeDisplayMode returns default value (list) when no value is set', () async {
+        // Act
+        final result = await settingsRepository.getBarcodeDisplayMode();
+
+        // Assert
+        expect(result, BarcodeDisplayMode.list);
+      });
+
+      test('setBarcodeDisplayMode and getBarcodeDisplayMode work correctly', () async {
+        // Act & Assert for carousel
+        await settingsRepository.setBarcodeDisplayMode(BarcodeDisplayMode.carousel);
+        var result = await settingsRepository.getBarcodeDisplayMode();
+        expect(result, BarcodeDisplayMode.carousel);
+
+        // Act & Assert for list
+        await settingsRepository.setBarcodeDisplayMode(BarcodeDisplayMode.list);
+        result = await settingsRepository.getBarcodeDisplayMode();
+        expect(result, BarcodeDisplayMode.list);
+      });
+    });
   });
 }

--- a/test/features/settings/presentation/settings_page_test.mocks.dart
+++ b/test/features/settings/presentation/settings_page_test.mocks.dart
@@ -5,7 +5,8 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i5;
 
-import 'package:barcodes/features/settings/data/settings_repository.dart' as _i4;
+import 'package:barcodes/features/settings/data/settings_repository.dart'
+    as _i4;
 import 'package:barcodes/utils/data_store.dart' as _i2;
 import 'package:mockito/mockito.dart' as _i1;
 import 'package:sembast/sembast.dart' as _i3;
@@ -25,17 +26,22 @@ import 'package:sembast/sembast.dart' as _i3;
 // ignore_for_file: subtype_of_sealed_class
 
 class _FakeDataStore_0 extends _i1.SmartFake implements _i2.DataStore {
-  _FakeDataStore_0(Object parent, Invocation parentInvocation) : super(parent, parentInvocation);
+  _FakeDataStore_0(Object parent, Invocation parentInvocation)
+    : super(parent, parentInvocation);
 }
 
-class _FakeStoreRef_1<K extends Object?, V extends Object?> extends _i1.SmartFake implements _i3.StoreRef<K, V> {
-  _FakeStoreRef_1(Object parent, Invocation parentInvocation) : super(parent, parentInvocation);
+class _FakeStoreRef_1<K extends Object?, V extends Object?>
+    extends _i1.SmartFake
+    implements _i3.StoreRef<K, V> {
+  _FakeStoreRef_1(Object parent, Invocation parentInvocation)
+    : super(parent, parentInvocation);
 }
 
 /// A class which mocks [SettingsRepository].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockSettingsRepository extends _i1.Mock implements _i4.SettingsRepository {
+class MockSettingsRepository extends _i1.Mock
+    implements _i4.SettingsRepository {
   @override
   _i2.DataStore get datastore =>
       (super.noSuchMethod(
@@ -98,6 +104,28 @@ class MockSettingsRepository extends _i1.Mock implements _i4.SettingsRepository 
   _i5.Future<void> setMaxScreenBrightnessLevel(double? value) =>
       (super.noSuchMethod(
             Invocation.method(#setMaxScreenBrightnessLevel, [value]),
+            returnValue: _i5.Future<void>.value(),
+            returnValueForMissingStub: _i5.Future<void>.value(),
+          )
+          as _i5.Future<void>);
+
+  @override
+  _i5.Future<_i4.BarcodeDisplayMode> getBarcodeDisplayMode() =>
+      (super.noSuchMethod(
+            Invocation.method(#getBarcodeDisplayMode, []),
+            returnValue: _i5.Future<_i4.BarcodeDisplayMode>.value(
+              _i4.BarcodeDisplayMode.list,
+            ),
+            returnValueForMissingStub: _i5.Future<_i4.BarcodeDisplayMode>.value(
+              _i4.BarcodeDisplayMode.list,
+            ),
+          )
+          as _i5.Future<_i4.BarcodeDisplayMode>);
+
+  @override
+  _i5.Future<void> setBarcodeDisplayMode(_i4.BarcodeDisplayMode? mode) =>
+      (super.noSuchMethod(
+            Invocation.method(#setBarcodeDisplayMode, [mode]),
             returnValue: _i5.Future<void>.value(),
             returnValueForMissingStub: _i5.Future<void>.value(),
           )


### PR DESCRIPTION
## Description
This commit introduces a new setting that allows you to choose how barcodes are displayed.

The following changes were made:

- Added a `BarcodeDisplayMode` enum (`list` or `carousel`) and corresponding getter/setter in `SettingsRepository`.
- Added a `SegmentedButton` in `SettingsPage` to control this setting.
- Updated `BarcodesPage` to conditionally display either `BarcodesList` or a placeholder for the carousel view based on the selected setting.
- Added unit tests for `SettingsRepository` and widget tests for `SettingsPage` and `BarcodesPage` to ensure the new functionality works as expected and existing functionality remains unaffected.


## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
