### PR TITLE
Refactor: Introduce BarcodeCard widget and update BarcodeScreen

### DIFF
--- a/lib/features/barcodes/presentation/barcode_card.dart
+++ b/lib/features/barcodes/presentation/barcode_card.dart
@@ -1,0 +1,67 @@
+import 'package:barcode_widget/barcode_widget.dart';
+import 'package:barcodes/features/barcodes/domain/barcode_conf.dart';
+import 'package:barcodes/features/barcodes/domain/barcode_entry.dart';
+import 'package:barcodes/features/barcodes/presentation/barcode_info.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart'; // Added for potential future use, not strictly needed now
+import 'package:barcodes/utils/logger.dart'; // Added for potential future use
+
+class BarcodeCard extends ConsumerWidget {
+  const BarcodeCard({
+    super.key,
+    required this.entry,
+    required this.onDoubleTap,
+  });
+
+  final BarcodeEntry entry;
+  final VoidCallback onDoubleTap;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final conf = BarcodeConf(entry.data, entry.type);
+
+    // It's good practice to handle potential errors during barcode verification
+    try {
+      conf.barcode.verify(conf.normalizedData);
+    } on BarcodeException catch (error) {
+      // Log the error and return an error message widget
+      ref.read(loggerProvider).e('Error verifying barcode: \$error');
+      return Card(
+        margin: const EdgeInsets.all(12),
+        child: Padding(
+          padding: const EdgeInsets.all(16.0),
+          child: Text(
+            'Error displaying barcode: \${error.message}',
+            style: const TextStyle(color: Colors.red),
+            textAlign: TextAlign.center,
+          ),
+        ),
+      );
+    }
+
+    return Card(
+      margin: const EdgeInsets.all(12),
+      child: Column(
+        children: [
+          Container(
+            alignment: Alignment.topCenter,
+            child: GestureDetector(
+              onDoubleTap: onDoubleTap,
+              child: BarcodeWidget(
+                padding: const EdgeInsets.all(12),
+                data: conf.normalizedData,
+                barcode: conf.barcode,
+                height: conf.height,
+                width: conf.width,
+                style: TextStyle(fontSize: conf.fontSize),
+              ),
+            ),
+          ),
+          BarcodeInfo(
+            entry: entry,
+          ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Description
This commit refactors the BarcodeScreen to use a new BarcodeCard widget. The BarcodeCard encapsulates the display of the barcode image and its associated information (name, type, comment), which was previously handled directly within BarcodeScreen using a generic Card and the BarcodeInfo widget.

Changes:
- Created `lib/features/barcodes/presentation/barcode_card.dart` containing the new `BarcodeCard` widget.
- `BarcodeCard` takes a `BarcodeEntry` and an `onDoubleTap` callback.
- Updated `BarcodeScreen` to use `BarcodeCard`, passing the necessary data.
- Removed direct usage of `BarcodeWidget` and `BarcodeInfo` from `BarcodeScreen` as they are now part of `BarcodeCard`.
- Cleaned up unused imports in `barcode_screen.dart`.

This change is part of a larger plan to simplify the Carousel view implementation.

Note: I could not run automated tests for this change due to execution environment timeouts (flutter pub get, flutter gen-l10n, flutter test). Manual verification of the BarcodeScreen's functionality is recommended.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
